### PR TITLE
Fix overlay hidden state

### DIFF
--- a/main.css
+++ b/main.css
@@ -50,6 +50,10 @@ body {
     flex-direction: column;
     z-index: 10;
 }
+/* Hide overlay when it has the .hidden class */
+#goal-overlay.hidden {
+    display: none;
+}
 
 .hidden {
     display: none;


### PR DESCRIPTION
## Summary
- ensure the goal overlay is hidden on load by adding a more specific CSS rule

## Testing
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_688ad42acbf88325a8401b9b793bc574