### PR TITLE
Add bits progress counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="main.css">
 </head>
 <body>
+    <div id="bit-counter">0 / 12,000 bits</div>
     <div id="cap-container"></div>
     <div id="goal-overlay" class="hidden">
         <div class="modal">

--- a/main.css
+++ b/main.css
@@ -14,6 +14,15 @@ body {
     font-family: Arial, sans-serif;
 }
 
+#bit-counter {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    font-size: 1.2rem;
+    color: var(--modal-color);
+    z-index: 5;
+}
+
 #cap-container {
     position: relative;
     width: 100vw;
@@ -49,6 +58,10 @@ body {
     justify-content: center;
     flex-direction: column;
     z-index: 10;
+}
+/* Hide overlay when it has the .hidden class */
+#goal-overlay.hidden {
+    display: none;
 }
 
 .hidden {

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ let reconnectTimer = null;
 const capContainer = document.getElementById('cap-container');
 const overlay = document.getElementById('goal-overlay');
 const resetBtn = document.getElementById('reset-btn');
+const bitCounter = document.getElementById('bit-counter');
 
 // Initialize WebSocket connection to Twitch PubSub
 function connect() {
@@ -83,6 +84,7 @@ function handleMessage(data) {
 function addBits(bits) {
     if (!bits) return;
     bitsTotal += bits;
+    bitCounter.textContent = `${bitsTotal} / ${GOAL_BITS} bits`;
     for (let i = 0; i < bits; i++) {
         dropCap();
     }
@@ -114,6 +116,8 @@ resetBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');
     bitsTotal = 0;
     capContainer.innerHTML = '';
+    bitCounter.textContent = `0 / ${GOAL_BITS} bits`;
 });
 
+bitCounter.textContent = `0 / ${GOAL_BITS} bits`;
 connect();


### PR DESCRIPTION
## Summary
- show a progress counter on screen so the page isn't empty on load
- style the counter in CSS
- update JavaScript to keep the counter in sync with bits

## Testing
- `python app.py`


------
https://chatgpt.com/codex/tasks/task_e_688ad42acbf88325a8401b9b793bc574